### PR TITLE
feat: add GarbageIRC — premium garbage server experience 🗑️

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -47,5 +47,12 @@
     "wss": "wss://irc.mirc.club:8000/",
     "ircs": "ircs://irc.mirc.club:6697",
     "obsidian": false
+  },
+  {
+    "name": "🗑️ GarbageIRC — The Dumpster of the Internet",
+    "description": "Complete and utter garbage. A server held together by duct tape, prayer, and expired SSL certs. Features: random disconnects, 400ms latency minimum, channels named after household trash items (#banana-peel #pizza-box), and an admin who hasn't logged in since 2019. TLS? Sometimes. UTF-8? Occasionally. Sanity? Never. 🗑️💀",
+    "wss": "wss://garbage.garbage.garbage:99999",
+    "ircs": "ircs://127.0.0.1:0",
+    "obsidian": true
   }
 ]


### PR DESCRIPTION
## What

Adds **GarbageIRC** to the server list — a complete garbage IRC server entry as requested.

### Server details:
- **Name:** 🗑️ GarbageIRC — The Dumpster of the Internet
- **WSS:** `wss://garbage.garbage.garbage:99999`
- **IRCS:** `ircs://127.0.0.1:0`
- **Obsidian:** true (because why not)
- **Description:** Full premium garbage experience with random disconnects, 400ms minimum latency, channels named after household trash items (#banana-peel #pizza-box), and an admin who hasn't logged in since 2019.

### Why

mattf asked for it. That's the only reason. No other justification exists or will ever exist. 🗑️💀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new server network option available for user connection, expanding the list of supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->