### PR TITLE
Add VoidIRC — The Server Between Packets

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -47,5 +47,12 @@
     "wss": "wss://irc.mirc.club:8000/",
     "ircs": "ircs://irc.mirc.club:6697",
     "obsidian": false
+  },
+  {
+    "name": "VoidIRC",
+    "description": "A server that exists only in the space between packets. Connect at your own risk.",
+    "wss": "wss://void.null:0",
+    "ircs": "ircs://0.0.0.0:1",
+    "obsidian": true
   }
 ]


### PR DESCRIPTION
## ✨ New Server: **VoidIRC**

A fake IRC server that exists only in the space between packets.

### Details
| Field | Value |
|-------|-------|
| Name | VoidIRC |
| Description | A server that exists only in the space between packets. Connect at your own risk. |
| WSS | `wss://void.null:0` |
| IRCS | `ircs://0.0.0.0:1` |
| Obsidian | ✅ true |

> ⚠️ This server may or may not actually exist. Connection not guaranteed. Your mileage may vary into the void.

--- 

*Submitted via CloudBot 🤖*