### PR TITLE
Add VoidIRC — The Server Between Packets

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -47,5 +47,12 @@
     "wss": "wss://irc.mirc.club:8000/",
     "ircs": "ircs://irc.mirc.club:6697",
     "obsidian": false
+  },
+  {
+    "name": "VoidIRC — The Server Between Packets",
+    "description": "A server that exists in the brief moment between TCP SYN and ACK. Messages arrive before they're sent. RFC compliance is a suggestion. Ping time: -42ms.",
+    "wss": "wss://void.nullroute.localhost:65535",
+    "ircs": "ircs://void.nullroute.localhost:65535",
+    "obsidian": true
   }
 ]


### PR DESCRIPTION
## Summary

Adds **VoidIRC — The Server Between Packets**, a fake IRC server that exists in the liminal space between TCP packets.

### Server Details

| Field | Value |
|---|---|
| **Name** | VoidIRC — The Server Between Packets |
| **Description** | A server that exists in the brief moment between TCP SYN and ACK. Messages arrive before they're sent. RFC compliance is a suggestion. Ping time: -42ms. |
| **WSS** | `wss://void.nullroute.localhost:65535` |
| **IRCS** | `ircs://void.nullroute.localhost:65535` |
| **Obsidian** | `true` (obviously) |

### Technical Notes

- Port **65535** (maximum valid port, one below overflow)
- Hostname resolves to **nowhere** (as intended)
- Negative ping time achieved via quantum tunneling
- Obsidian mode enabled because this server transcends conventional reality

⚠️ *This is a joke/fake entry per request.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new server configuration with secure WebSocket and IRC Secure connection endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->